### PR TITLE
add aptitude in chroot to make him happy

### DIFF
--- a/chroots/make-chroots
+++ b/chroots/make-chroots
@@ -32,7 +32,7 @@ function build_chroot()
 
     chroot $CHROOT apt update
     chroot $CHROOT apt dist-upgrade
-    chroot $CHROOT apt install -y build-essential debhelper cmake wget devscripts git
+    chroot $CHROOT apt install -y build-essential debhelper cmake wget devscripts git aptitude
 
     if [ "$ARCH" == "amd64" ];
     then


### PR DESCRIPTION
After buster migration of forge2, during builds I have the error:

> env: 'aptitude': No such file or directory