### PR TITLE
Graciously avoid forced-pushed tags snafus

### DIFF
--- a/ynh-build
+++ b/ynh-build
@@ -61,7 +61,7 @@ function checkout_tag()
 
     cd "$GIT_REPOS/$PROJECT" || exit 1
     git fetch --quiet
-    git fetch --tags --quiet
+    git fetch --tags --quiet --force
     git checkout "$TAG" --quiet
     git reset --hard "$TAG" --quiet
 


### PR DESCRIPTION
In the obviously never-happening instances of wanting to force-push fixes in failed builds, it is better to force the retrieval of changed tags.